### PR TITLE
Remove ENV to simplify example

### DIFF
--- a/voice/outbound_tts_call.rb
+++ b/voice/outbound_tts_call.rb
@@ -1,13 +1,6 @@
-require 'dotenv'
 require 'nexmo'
 
-Dotenv.load
-
-APPLICATION_ID = ENV['APPLICATION_ID']
-PRIVATE_KEY_PATH = ENV['PRIVATE_KEY_PATH']
 PRIVATE_KEY = File.read(PRIVATE_KEY_PATH)
-FROM_NUMBER = ENV['FROM_NUMBER']
-TO_NUMBER = ENV['FROM_NUMBER']
 
 client = Nexmo::Client.new(
   application_id: APPLICATION_ID,


### PR DESCRIPTION
Simplified the example by removing the `.env` file concern but keeping the `PRIVATE_KEY_PATH` and `PRIVATE_KEY` separate for explicit clarity.