### PR TITLE
Additional examples

### DIFF
--- a/application/create.rb
+++ b/application/create.rb
@@ -1,0 +1,29 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+
+puts "Enter the application name."
+name = gets.chomp
+
+puts "Enter the answer url."
+answer_url = gets.chomp
+
+puts "Enter the event url."
+event_url = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.create_application(
+	name: name,
+	type: 'voice',
+	answer_url: answer_url,
+	event_url: event_url)
+
+puts response

--- a/application/delete.rb
+++ b/application/delete.rb
@@ -1,0 +1,19 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+
+puts "Enter the application uuid."
+uuid = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.delete_application(uuid)
+
+puts response

--- a/number/buy.rb
+++ b/number/buy.rb
@@ -1,0 +1,24 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+
+puts "Enter the country code."
+country = gets.chomp
+
+puts "Enter the phone number's msisdn."
+msisdn = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.buy_number(country: country, msisdn: msisdn)
+
+# NOTE: Even though the operation was succesful, the response will look like:
+# {"error-code"=>"200", "error-code-label"=>"success"}
+puts response

--- a/number_insight/advanced.rb
+++ b/number_insight/advanced.rb
@@ -1,0 +1,22 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+
+puts "Enter the number to lookup, leading with the country code."
+
+number = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.get_advanced_number_insight(
+  number: number
+)
+
+puts response

--- a/number_insight/basic.rb
+++ b/number_insight/basic.rb
@@ -1,0 +1,22 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+
+puts "Enter the number to lookup, leading with the country code."
+
+number = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.get_basic_number_insight(
+  number: number
+)
+
+puts response

--- a/number_insight/standard.rb
+++ b/number_insight/standard.rb
@@ -1,0 +1,22 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+
+puts "Enter the number to lookup, leading with the country code."
+
+number = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.get_standard_number_insight(
+  number: number
+)
+
+puts response

--- a/sms/send_unicode.rb
+++ b/sms/send_unicode.rb
@@ -1,0 +1,23 @@
+require 'dotenv'
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+FROM_NUMBER = ENV['FROM_NUMBER']
+TO_NUMBER = ENV['TO_NUMBER']
+
+require 'nexmo'
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET
+)
+
+response = client.send_message(
+  from: FROM_NUMBER,
+  to: TO_NUMBER,
+  text: "Blue Öyster Cult 🤘",
+  type: "unicode"
+)
+
+puts response

--- a/voice/collect_dtmf_input.rb
+++ b/voice/collect_dtmf_input.rb
@@ -1,0 +1,38 @@
+require 'json'
+require 'sinatra'
+
+get '/ncco' do
+  content_type :json
+  [
+    {
+      "action": "talk",
+      "text": "Please enter three digits"
+    },
+    {
+      "action": "input",
+      "timeOut": 20,
+      "maxDigits": 3,
+      "eventUrl": ["#{base_url}/ivr"]
+    }
+  ].to_json
+end
+
+post '/event' do
+  puts JSON.parse(request.body.read)
+end
+
+post '/ivr' do
+  puts JSON.parse(request.body.read)
+end
+
+def base_url
+  @base_url ||= "#{url_scheme}://#{http_host}"
+end
+
+def url_scheme
+  request.env['rack.url_scheme']
+end
+
+def http_host
+  request.env['HTTP_HOST']
+end

--- a/voice/conference_call.rb
+++ b/voice/conference_call.rb
@@ -1,0 +1,32 @@
+require 'json'
+require 'sinatra'
+
+get '/ncco' do
+  content_type :json
+  [
+    {
+      "action": "talk",
+      "text": "Welcome to the amazing Nexmo conference call"
+    },
+    {
+      "action": "conversation",
+      "name": "amazing-conference-call"
+    }
+  ].to_json
+end
+
+post '/event' do
+  puts JSON.parse(request.body.read)
+end
+
+def base_url
+  @base_url ||= "#{url_scheme}://#{http_host}"
+end
+
+def url_scheme
+  request.env['rack.url_scheme']
+end
+
+def http_host
+  request.env['HTTP_HOST']
+end

--- a/voice/record_call.rb
+++ b/voice/record_call.rb
@@ -1,0 +1,46 @@
+require 'json'
+require 'sinatra'
+
+get '/ncco' do
+  content_type :json
+  [
+    {
+      "action": "talk",
+      "text": "Please leave a message after the tone, then press #. We will get back to you as soon as we can",
+      "voiceName": "Emma"
+    },
+    {
+      "action": "record",
+      "eventUrl": [
+          "#{base_url}/voicemails"
+      ],
+      "endOnSilence": "3",
+      "endOnKey" => "#",
+      "beepStart": "true"
+    },
+    {
+      "action": "talk",
+      "text": "Thank you for your message. Goodbye"
+    }
+  ].to_json
+end
+
+post '/voicemails' do
+  puts JSON.parse(request.body.read)
+end
+
+post '/event' do
+  puts JSON.parse(request.body.read)
+end
+
+def base_url
+  @base_url ||= "#{url_scheme}://#{http_host}"
+end
+
+def url_scheme
+  request.env['rack.url_scheme']
+end
+
+def http_host
+  request.env['HTTP_HOST']
+end

--- a/voice/retrieve_recording.rb
+++ b/voice/retrieve_recording.rb
@@ -1,0 +1,27 @@
+require 'dotenv'
+require 'nexmo'
+
+Dotenv.load
+
+API_KEY = ENV['API_KEY']
+API_SECRET = ENV['API_SECRET']
+APPLICATION_ID = ENV['APPLICATION_ID']
+PRIVATE_KEY = ENV['PRIVATE_KEY']
+
+puts "What is the conversation_uuid?"
+
+# The conversation uuid will come from a recording's event url. 
+# It can be conversation_uuid without the leading "CON-"
+# or it can be the last path segment in the recording_url.
+conversation_uuid = gets.chomp
+
+client = Nexmo::Client.new(
+  key: API_KEY,
+  secret: API_SECRET,
+  application_id: APPLICATION_ID,
+  private_key: File.read(PRIVATE_KEY)
+)
+
+response = client.get_file(conversation_uuid)
+
+File.write("recording.mp3", response)

--- a/voice/retrieve_recording.rb
+++ b/voice/retrieve_recording.rb
@@ -8,11 +8,8 @@ API_SECRET = ENV['API_SECRET']
 APPLICATION_ID = ENV['APPLICATION_ID']
 PRIVATE_KEY = ENV['PRIVATE_KEY']
 
-puts "What is the conversation_uuid?"
+puts "What is the Call's recording_url?"
 
-# The conversation uuid will come from a recording's event url. 
-# It can be conversation_uuid without the leading "CON-"
-# or it can be the last path segment in the recording_url.
 conversation_uuid = gets.chomp
 
 client = Nexmo::Client.new(

--- a/voice/websocket_echo_server.rb
+++ b/voice/websocket_echo_server.rb
@@ -65,7 +65,7 @@ get '/ncco' do
 end
 
 post '/event' do
-  puts params
+  puts request.body
 end
 
 def base_url


### PR DESCRIPTION
- Voice api examples 
  - Collect DTMF input
  - Create a conference call
  - Record a call
  - Retrieve a recording of a call
- Send SMS with unicode
- Buy a number
- Number insights
  - Basic
  - Standard
  - Advanced
- Application
  - Create
  - Delete

Minor fixup to use correct logging for event url
